### PR TITLE
Add Unity prototype scaffold

### DIFF
--- a/Assets/Scenes/TestArena.unity
+++ b/Assets/Scenes/TestArena.unity
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1
+GameObject:
+  m_Name: TestArenaRoot
+  m_IsActive: 1
+  m_Component:
+  - component: {fileID: 4}
+--- !u!4 &4
+Transform:
+  m_GameObject: {fileID: 1}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}

--- a/Assets/Scripts/Network/DummyNetworkManager.cs
+++ b/Assets/Scripts/Network/DummyNetworkManager.cs
@@ -1,0 +1,26 @@
+using UnityEngine;
+
+/// <summary>
+/// Simulates UDP send and receive logs for development.
+/// </summary>
+public class DummyNetworkManager : MonoBehaviour
+{
+    /// <summary>
+    /// Logs that the dummy network manager is active.
+    /// </summary>
+    private void Start()
+    {
+        Debug.Log("[Network] Dummy network manager initialized.");
+    }
+
+    /// <summary>
+    /// Logs simulated packet transmission when the player moves.
+    /// </summary>
+    /// <param name="position">Current player position.</param>
+    public void SendPlayerPosition(Vector3 position)
+    {
+        Debug.Log($"[Network] UDP Send: {position}");
+        Debug.Log($"[Network] UDP Receive: ack for {position}");
+    }
+}
+

--- a/Assets/Scripts/Player/PlayerController.cs
+++ b/Assets/Scripts/Player/PlayerController.cs
@@ -1,0 +1,116 @@
+using UnityEngine;
+using UnityEngine.InputSystem;
+using Cinemachine;
+
+/// <summary>
+/// Handles player movement, camera rotation and jump logic.
+/// </summary>
+[RequireComponent(typeof(CharacterController))]
+public class PlayerController : MonoBehaviour
+{
+    [Header("Movement")]
+    [Tooltip("Movement speed in units per second.")]
+    public float moveSpeed = 5f;
+
+    [Tooltip("Jump height in meters.")]
+    public float jumpHeight = 2f;
+
+    [Tooltip("Gravity force.")]
+    public float gravity = -9.81f;
+
+    [Header("Camera")]
+    [Tooltip("Root transform for the camera to rotate around.")]
+    public Transform cameraRoot;
+
+    [Tooltip("Cinemachine virtual camera following the player.")]
+    public CinemachineVirtualCamera followCamera;
+
+    private CharacterController controller;
+    private Vector3 velocity;
+    private Vector3 lastSentPosition;
+    private DummyNetworkManager network;
+
+    private InputAction moveAction;
+    private InputAction lookAction;
+    private InputAction jumpAction;
+
+    private const float lookSensitivity = 0.1f;
+
+    private void Awake()
+    {
+        controller = GetComponent<CharacterController>();
+        network = GetComponent<DummyNetworkManager>();
+        
+        var map = new InputActionMap("Player");
+        moveAction = map.AddAction("Move", binding: "<Gamepad>/leftStick");
+        moveAction.AddCompositeBinding("2DVector")
+            .With("Up", "<Keyboard>/w")
+            .With("Down", "<Keyboard>/s")
+            .With("Left", "<Keyboard>/a")
+            .With("Right", "<Keyboard>/d");
+
+        lookAction = map.AddAction("Look", binding: "<Mouse>/delta");
+        jumpAction = map.AddAction("Jump", binding: "<Keyboard>/space");
+        map.Enable();
+
+        if (followCamera != null)
+        {
+            followCamera.Follow = cameraRoot;
+        }
+    }
+
+    private void Update()
+    {
+        HandleMovement();
+        HandleMouseLook();
+        HandleJump();
+    }
+
+    /// <summary>
+    /// Reads WASD movement and moves the CharacterController.
+    /// </summary>
+    private void HandleMovement()
+    {
+        Vector2 input = moveAction.ReadValue<Vector2>();
+        Vector3 direction = new Vector3(input.x, 0f, input.y);
+        direction = Quaternion.Euler(0f, cameraRoot.eulerAngles.y, 0f) * direction;
+        controller.Move(direction * moveSpeed * Time.deltaTime);
+
+        if (controller.isGrounded && velocity.y < 0f)
+        {
+            velocity.y = -2f; // Small downward force to stick to ground
+        }
+        velocity.y += gravity * Time.deltaTime;
+        controller.Move(velocity * Time.deltaTime);
+
+        if (network != null && Vector3.Distance(transform.position, lastSentPosition) > 0.1f)
+        {
+            network.SendPlayerPosition(transform.position);
+            lastSentPosition = transform.position;
+        }
+    }
+
+    /// <summary>
+    /// Handles mouse-controlled camera rotation while holding the right button.
+    /// </summary>
+    private void HandleMouseLook()
+    {
+        if (Mouse.current.rightButton.isPressed)
+        {
+            Vector2 lookDelta = lookAction.ReadValue<Vector2>();
+            cameraRoot.Rotate(Vector3.up, lookDelta.x * lookSensitivity, Space.World);
+        }
+    }
+
+    /// <summary>
+    /// Applies jump velocity when the jump action is triggered.
+    /// </summary>
+    private void HandleJump()
+    {
+        if (jumpAction.triggered && controller.isGrounded)
+        {
+            velocity.y = Mathf.Sqrt(jumpHeight * -2f * gravity);
+        }
+    }
+}
+

--- a/Assets/Scripts/Player/Targeting.cs
+++ b/Assets/Scripts/Player/Targeting.cs
@@ -1,0 +1,113 @@
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.InputSystem;
+
+/// <summary>
+/// Provides simple tab-target functionality for nearby enemies.
+/// </summary>
+public class Targeting : MonoBehaviour
+{
+    [Tooltip("Radius used to search for enemies when tabbing.")]
+    public float targetRadius = 20f;
+
+    [Tooltip("Material color applied to the current target.")]
+    public Color highlightColor = Color.red;
+
+    private List<GameObject> targets = new();
+    private int currentIndex = -1;
+    private GameObject currentTarget;
+    private Color originalColor;
+
+    private InputAction tabAction;
+
+    /// <summary>
+    /// Fired when the selected target changes.
+    /// </summary>
+    public System.Action<GameObject> OnTargetChanged;
+
+    private void Awake()
+    {
+        var map = new InputActionMap("Targeting");
+        tabAction = map.AddAction("Tab", binding: "<Keyboard>/tab");
+        map.Enable();
+    }
+
+    private void Update()
+    {
+        if (tabAction.triggered)
+        {
+            AcquireTargets();
+            CycleTarget();
+        }
+    }
+
+    /// <summary>
+    /// Finds all enemy objects within the target radius.
+    /// </summary>
+    private void AcquireTargets()
+    {
+        Collider[] cols = Physics.OverlapSphere(transform.position, targetRadius);
+        targets.Clear();
+        foreach (var col in cols)
+        {
+            if (col.CompareTag("Enemy"))
+            {
+                targets.Add(col.gameObject);
+            }
+        }
+
+        targets.Sort((a, b) =>
+            Vector3.Distance(transform.position, a.transform.position)
+                .CompareTo(Vector3.Distance(transform.position, b.transform.position)));
+    }
+
+    /// <summary>
+    /// Selects the next target in the list.
+    /// </summary>
+    private void CycleTarget()
+    {
+        if (targets.Count == 0)
+        {
+            ClearTarget();
+            return;
+        }
+
+        currentIndex = (currentIndex + 1) % targets.Count;
+        SetTarget(targets[currentIndex]);
+    }
+
+    /// <summary>
+    /// Applies highlight to the specified GameObject.
+    /// </summary>
+    /// <param name="target">Target to select.</param>
+    private void SetTarget(GameObject target)
+    {
+        ClearTarget();
+        currentTarget = target;
+        Renderer r = currentTarget.GetComponentInChildren<Renderer>();
+        if (r != null)
+        {
+            originalColor = r.material.color;
+            r.material.color = highlightColor;
+        }
+        OnTargetChanged?.Invoke(currentTarget);
+    }
+
+    /// <summary>
+    /// Removes highlight from the current target.
+    /// </summary>
+    private void ClearTarget()
+    {
+        if (currentTarget != null)
+        {
+            Renderer r = currentTarget.GetComponentInChildren<Renderer>();
+            if (r != null)
+            {
+                r.material.color = originalColor;
+            }
+        }
+        currentTarget = null;
+        OnTargetChanged?.Invoke(null);
+    }
+}
+

--- a/Assets/Scripts/SceneBootstrapper.cs
+++ b/Assets/Scripts/SceneBootstrapper.cs
@@ -1,0 +1,96 @@
+using UnityEngine;
+using UnityEngine.UI;
+using Cinemachine;
+
+/// <summary>
+/// Creates placeholder objects for the TestArena scene at runtime.
+/// </summary>
+public static class SceneBootstrapper
+{
+    [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
+    private static void CreateSceneObjects()
+    {
+        // Ground plane
+        GameObject ground = GameObject.CreatePrimitive(PrimitiveType.Plane);
+        ground.name = "Ground";
+
+        // Directional light
+        GameObject lightObj = new GameObject("Directional Light");
+        Light light = lightObj.AddComponent<Light>();
+        light.type = LightType.Directional;
+        light.transform.rotation = Quaternion.Euler(50f, -30f, 0f);
+
+        // Player capsule
+        GameObject player = GameObject.CreatePrimitive(PrimitiveType.Capsule);
+        player.name = "Player";
+        player.transform.position = new Vector3(0f, 1f, 0f);
+        var controller = player.AddComponent<CharacterController>();
+        player.AddComponent<PlayerController>();
+        var targeting = player.AddComponent<Targeting>();
+        player.AddComponent<DummyNetworkManager>();
+
+        // Camera root and Cinemachine virtual camera
+        GameObject cameraRoot = new GameObject("CameraRoot");
+        cameraRoot.transform.SetParent(player.transform);
+        cameraRoot.transform.localPosition = Vector3.zero;
+        var camObj = new GameObject("Main Camera");
+        Camera cam = camObj.AddComponent<Camera>();
+        cam.tag = "MainCamera";
+        camObj.transform.SetParent(cameraRoot.transform);
+        camObj.transform.localPosition = new Vector3(0f, 2f, -4f);
+        camObj.transform.localRotation = Quaternion.identity;
+        var vcam = camObj.AddComponent<CinemachineVirtualCamera>();
+        vcam.Follow = cameraRoot.transform;
+
+        var pc = player.GetComponent<PlayerController>();
+        pc.cameraRoot = cameraRoot.transform;
+        pc.followCamera = vcam;
+
+        // NPC target
+        GameObject npc = GameObject.CreatePrimitive(PrimitiveType.Capsule);
+        npc.name = "Enemy";
+        npc.tag = "Enemy";
+        npc.transform.position = new Vector3(2f, 1f, 5f);
+
+        // UI setup
+        GameObject canvasObj = new GameObject("Canvas");
+        var canvas = canvasObj.AddComponent<Canvas>();
+        canvas.renderMode = RenderMode.ScreenSpaceOverlay;
+        canvasObj.AddComponent<CanvasScaler>();
+        canvasObj.AddComponent<GraphicRaycaster>();
+
+        GameObject panel = new GameObject("TargetUI");
+        panel.transform.SetParent(canvasObj.transform);
+        var panelRect = panel.AddComponent<RectTransform>();
+        panelRect.anchorMin = new Vector2(0.5f, 1f);
+        panelRect.anchorMax = new Vector2(0.5f, 1f);
+        panelRect.anchoredPosition = new Vector2(0f, -40f);
+        panelRect.sizeDelta = new Vector2(200f, 40f);
+
+        GameObject textObj = new GameObject("Name");
+        textObj.transform.SetParent(panel.transform);
+        var nameText = textObj.AddComponent<Text>();
+        nameText.font = Resources.GetBuiltinResource<Font>("Arial.ttf");
+        nameText.alignment = TextAnchor.MiddleCenter;
+        var nameRect = nameText.GetComponent<RectTransform>();
+        nameRect.anchorMin = new Vector2(0f, 0.5f);
+        nameRect.anchorMax = new Vector2(1f, 1f);
+        nameRect.offsetMin = Vector2.zero;
+        nameRect.offsetMax = Vector2.zero;
+
+        GameObject sliderObj = new GameObject("HP");
+        sliderObj.transform.SetParent(panel.transform);
+        var slider = sliderObj.AddComponent<Slider>();
+        var sliderRect = slider.GetComponent<RectTransform>();
+        sliderRect.anchorMin = new Vector2(0f, 0f);
+        sliderRect.anchorMax = new Vector2(1f, 0.5f);
+        sliderRect.offsetMin = Vector2.zero;
+        sliderRect.offsetMax = Vector2.zero;
+
+        var targetUI = panel.AddComponent<TargetUI>();
+        targetUI.targeting = targeting;
+        targetUI.nameLabel = nameText;
+        targetUI.hpBar = slider;
+    }
+}
+

--- a/Assets/Scripts/UI/TargetUI.cs
+++ b/Assets/Scripts/UI/TargetUI.cs
@@ -1,0 +1,56 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+/// <summary>
+/// Displays the selected target's name and health bar.
+/// </summary>
+public class TargetUI : MonoBehaviour
+{
+    [Tooltip("Targeting component to read target changes from.")]
+    public Targeting targeting;
+
+    [Tooltip("UI text element showing the target name.")]
+    public Text nameLabel;
+
+    [Tooltip("Slider representing target HP.")]
+    public Slider hpBar;
+
+    private void Awake()
+    {
+        if (targeting != null)
+        {
+            targeting.OnTargetChanged += OnTargetChanged;
+        }
+        ClearUI();
+    }
+
+    /// <summary>
+    /// Updates the UI when a new target is selected.
+    /// </summary>
+    /// <param name="obj">Selected target GameObject.</param>
+    private void OnTargetChanged(GameObject obj)
+    {
+        if (obj == null)
+        {
+            ClearUI();
+            return;
+        }
+
+        nameLabel.text = obj.name;
+        hpBar.value = 1f; // Placeholder full health
+        nameLabel.enabled = true;
+        hpBar.gameObject.SetActive(true);
+    }
+
+    /// <summary>
+    /// Clears the target UI.
+    /// </summary>
+    private void ClearUI()
+    {
+        nameLabel.text = string.Empty;
+        hpBar.value = 0f;
+        nameLabel.enabled = false;
+        hpBar.gameObject.SetActive(false);
+    }
+}
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,32 @@
-# mmo-frontend
+# MMO Frontend
+
+This repository contains a minimal Unity 2022 project scaffold for early MMO client development.
+
+## Project Structure
+
+```
+Assets/
+  Prefabs/
+  Scenes/
+    TestArena.unity
+  Scripts/
+    Network/
+      DummyNetworkManager.cs
+    Player/
+      PlayerController.cs
+      Targeting.cs
+    UI/
+      TargetUI.cs
+  SceneBootstrapper.cs
+```
+
+## Usage
+
+1. Open the project in **Unity 2022 LTS**.
+2. Ensure the **Input System** and **Cinemachine** packages are installed via the Package Manager.
+3. Open `Assets/Scenes/TestArena.unity` and press Play.
+4. Use **WASD** to move, **Space** to jump and **Right Mouse Button** to rotate the camera.
+5. Press **Tab** to cycle targets. Selected targets display their name and a placeholder HP bar at the top of the screen.
+
+All scene objects are created at runtime by `SceneBootstrapper` for simplicity.
+


### PR DESCRIPTION
## Summary
- create Unity folders and runtime scene bootstrapper
- implement player controller with Input System, Cinemachine camera, jumping and network logging
- implement tab-targeting with simple highlighting
- add dummy network manager
- add target UI script
- provide placeholder `TestArena` scene
- update README with usage instructions

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_686ed07d2d988331b820c6280a8f5199