### PR TITLE
Fix stub conflicts with Unity types

### DIFF
--- a/Assets/Scripts/Stubs/CinemachineStubs.cs
+++ b/Assets/Scripts/Stubs/CinemachineStubs.cs
@@ -1,5 +1,6 @@
 using UnityEngine;
 
+#if !UNITY_5_3_OR_NEWER
 namespace Cinemachine
 {
     public class CinemachineVirtualCamera : MonoBehaviour
@@ -7,3 +8,4 @@ namespace Cinemachine
         public Transform Follow { get; set; }
     }
 }
+#endif

--- a/Assets/Scripts/Stubs/InputSystemStubs.cs
+++ b/Assets/Scripts/Stubs/InputSystemStubs.cs
@@ -1,3 +1,4 @@
+#if !UNITY_5_3_OR_NEWER
 namespace UnityEngine.InputSystem
 {
     public class InputAction
@@ -27,3 +28,4 @@ namespace UnityEngine.InputSystem
         }
     }
 }
+#endif

--- a/Assets/Scripts/Stubs/UIStubs.cs
+++ b/Assets/Scripts/Stubs/UIStubs.cs
@@ -1,5 +1,6 @@
 using UnityEngine;
 
+#if !UNITY_5_3_OR_NEWER
 namespace UnityEngine.UI
 {
     public class Canvas : MonoBehaviour
@@ -20,7 +21,7 @@ namespace UnityEngine.UI
         public string text;
         public Font font;
         public TextAnchor alignment;
-        public bool enabled;
+        public new bool enabled;
     }
 
     public class Slider : MonoBehaviour
@@ -28,3 +29,4 @@ namespace UnityEngine.UI
         public float value;
     }
 }
+#endif

--- a/Assets/Scripts/Stubs/UnityEngineStubs.cs
+++ b/Assets/Scripts/Stubs/UnityEngineStubs.cs
@@ -1,3 +1,4 @@
+#if !UNITY_5_3_OR_NEWER
 namespace UnityEngine
 {
     public class Font {}
@@ -12,3 +13,4 @@ namespace UnityEngine
         public static T GetBuiltinResource<T>(string path) where T : class => null;
     }
 }
+#endif


### PR DESCRIPTION
## Summary
- wrap stub classes in a conditional so Unity's real APIs take precedence
- suppress behaviour-enabled hiding warning

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ed90155a483318264b8cc988f91fe