### PR TITLE
Fix enemy tag and builtin font

### DIFF
--- a/Assets/Scripts/SceneBootstrapper.cs
+++ b/Assets/Scripts/SceneBootstrapper.cs
@@ -70,7 +70,7 @@ public static class SceneBootstrapper
         GameObject textObj = new GameObject("Name");
         textObj.transform.SetParent(panel.transform);
         var nameText = textObj.AddComponent<Text>();
-        nameText.font = Resources.GetBuiltinResource<Font>("Arial.ttf");
+        nameText.font = Resources.GetBuiltinResource<Font>("LegacyRuntime.ttf");
         nameText.alignment = TextAnchor.MiddleCenter;
         var nameRect = nameText.GetComponent<RectTransform>();
         nameRect.anchorMin = new Vector2(0f, 0.5f);

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -3,7 +3,8 @@
 --- !u!78 &1
 TagManager:
   serializedVersion: 3
-  tags: []
+  tags:
+  - Enemy
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
## Summary
- define `Enemy` tag so runtime objects can use it
- update `SceneBootstrapper` to use the `LegacyRuntime.ttf` font instead of the old Arial built-in font

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_686f0aa81b9483318c774e4f4b153773