### PR TITLE
Improve player setup and hide capsule

### DIFF
--- a/Assets/Scripts/Player/PlayerController.cs
+++ b/Assets/Scripts/Player/PlayerController.cs
@@ -40,6 +40,19 @@ public class PlayerController : MonoBehaviour
     {
         controller = GetComponent<CharacterController>();
         network = GetComponent<DummyNetworkManager>();
+
+        // Hide the capsule mesh and remove the primitive collider if present
+        var meshRenderer = GetComponent<MeshRenderer>();
+        if (meshRenderer != null)
+        {
+            meshRenderer.enabled = false;
+        }
+
+        var primitiveCollider = GetComponent<CapsuleCollider>();
+        if (primitiveCollider != null)
+        {
+            Destroy(primitiveCollider);
+        }
         
         var map = new InputActionMap("Player");
         moveAction = map.AddAction("Move", binding: "<Gamepad>/leftStick");

--- a/Docs/CharacterSetup.md
+++ b/Docs/CharacterSetup.md
@@ -1,0 +1,22 @@
+# Character Setup Guidelines
+
+This project uses a simple player prefab composed of a physics capsule and a visual armature. The following structure keeps the hierarchy tidy and ensures the player only renders the model:
+
+```
+Player (root GameObject)
+├─ CharacterController + PlayerController
+└─ PlayerArmature (visuals only)
+    └─ cameraRoot (head transform)
+```
+
+* **Root (`Player`)**
+  * Contains the `CharacterController` component used for collisions.
+  * Holds the `PlayerController` script.
+  * Does **not** render a mesh. The capsule primitive is kept only for physics.
+* **PlayerArmature**
+  * Child object with the visible skinned mesh and animations.
+  * No scripts are attached directly to the armature.
+* **cameraRoot**
+  * Transform under the armature (usually at the head) used as the follow target for the Cinemachine camera.
+
+The `PlayerController` automatically disables any `MeshRenderer` or `CapsuleCollider` found on the root so the capsule mesh stays hidden in Play mode.

--- a/README.md
+++ b/README.md
@@ -31,4 +31,5 @@ Assets/
 5. Press **Tab** to cycle targets. Selected targets display their name and a placeholder HP bar at the top of the screen.
 
 All scene objects are created at runtime by `SceneBootstrapper` for simplicity.
+See `Docs/CharacterSetup.md` for details on structuring the player prefab and camera hierarchy.
 


### PR DESCRIPTION
## Summary
- prevent the capsule primitive from rendering by disabling its MeshRenderer
- drop the extra CapsuleCollider if present
- document how the player prefab should be structured
- link the new character setup docs from the README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686fc15ce2cc8331848c88ebf22937ef